### PR TITLE
Storage compression

### DIFF
--- a/mh-journal-historian.js
+++ b/mh-journal-historian.js
@@ -52,7 +52,7 @@
 		localStorage.setItem('mh-journal-historian',JSON.stringify(savedEntries));
 	}
 
-	const observerTarget = document.querySelector(`#journalEntries${user.user_id}`);
+	const observerTarget = document.querySelector(`#journalContainer .content`);
 	const observer = new MutationObserver(function (mutations) {
 		const mutationDebug = false;
 
@@ -64,13 +64,11 @@
 				console.log(mutation.target);
 			}
 		}
-		saveEntries();
-		renderBtns();
 
-		observer.observe(observerTarget, {
-			childList: true,
-			subtree: true
-		});
+		// Only save if something was added.
+		if (mutations.some(v => v.type === 'childList' && v.addedNodes.length > 0)) {
+			saveEntries();
+		}
 	});
 
 	observer.observe(observerTarget, {

--- a/mh-journal-historian.js
+++ b/mh-journal-historian.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MouseHunt - Journal Historian
 // @namespace    https://greasyfork.org/en/users/900615-personalpalimpsest
-// @version      1.0.1
+// @version      1.0.2
 // @license      GNU GPLv3
 // @description  Saves journal entries and offers more viewing options
 // @author       asterios

--- a/mh-journal-historian.js
+++ b/mh-journal-historian.js
@@ -10,10 +10,11 @@
 // @icon         https://www.mousehuntgame.com/images/mice/thumb/de5de32f7ece2076dc405016d0c53302.gif?cv=2
 // @grant        none
 // @require      https://cdnjs.cloudflare.com/ajax/libs/jquery-toast-plugin/1.3.2/jquery.toast.min.js
+// @require      https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js
 // ==/UserScript==
 
 (function () {
-	const debug = true;
+	const debug = false;
 
 	function entryStripper(entry) {
 		if (entry.classList.contains('animated')) {
@@ -30,7 +31,7 @@
 
 	function saveEntries() {
 		const entries = document.querySelectorAll('.entry');
-		const savedEntries = JSON.parse(localStorage.getItem('mh-journal-historian')) || [];
+		const savedEntries = getSavedEntriesFromStorage();
 
 		entries.forEach((entry) => {
 			const entryId = entry.dataset.entryId
@@ -49,7 +50,7 @@
 			}
 		})
 
-		localStorage.setItem('mh-journal-historian',JSON.stringify(savedEntries));
+		setSavedEntriesToStorage(savedEntries);
 	}
 
 	const observerTarget = document.querySelector(`#journalContainer .content`);
@@ -88,14 +89,34 @@
 	}
 
 	function renderSavedEntries() {
-		const savedEntries = JSON.parse(localStorage.getItem('mh-journal-historian')) || [];
+		const savedEntries = getSavedEntriesFromStorage();
 		const journal = document.querySelector(`#journalEntries${user.user_id}`);
-		savedEntries.forEach((entry)=>{
+		for (const [id, entry] of Object.entries(savedEntries)) {
 			if (entry) {
 				const frag = document.createRange().createContextualFragment(entry);
 				journal.prepend(frag);
 			}
-		})
+		}
+	}
+
+	function getSavedEntriesFromStorage() {
+		const compressed = localStorage.getItem('mh-journal-historian');
+		const decompressed = LZString.decompressFromUTF16(compressed);
+
+		var savedEntries;
+		try {
+			savedEntries = JSON.parse(decompressed);
+		} catch {
+			savedEntries = {};
+		}
+
+		return savedEntries;
+	}
+
+	function setSavedEntriesToStorage(entries) {
+		const savedEntries = JSON.stringify(entries);
+		const compressed = LZString.compressToUTF16(savedEntries);
+		localStorage.setItem('mh-journal-historian', compressed);
 	}
 
 	function mpCleanUp() {


### PR DESCRIPTION
- Change mutation observed node
- Compress storage and change to using dictionary
- Bump version

The problem with watching the journalEntries{user_id} node is that it's completely replaced when paging through. Observe slightly higher in the tree and you will get the desired effect. You also don't need to re-render the buttons.

⚠️ This will blow away current saved entries because you were storing it them as an array. I swapped to using a dictionary because it creates an unnecessarily large array when you use the entryid. I can submit another commit to keep backwards compatibility but it's more complex when the lifetime of the script is very short.

My local storage looked like this.
![image](https://user-images.githubusercontent.com/1909698/202492860-257f85ff-d61e-473e-9fc6-bd4f5c5c9325.png)
It didn't have an entry until about 139000th index. 

Compare with compressed: 
![image](https://user-images.githubusercontent.com/1909698/202492765-8471f7b4-41b2-4c49-8553-ec6bb2113891.png)

